### PR TITLE
#20: Allow panView to be overrideable in child view controllers.

### DIFF
--- a/TwitterProfile/Classes/Protocols/PannableViewsProtocol.swift
+++ b/TwitterProfile/Classes/Protocols/PannableViewsProtocol.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-protocol PannableViewsProtocol {
+public protocol PannableViewsProtocol {
     func panView() -> UIView
 }
 
-extension PannableViewsProtocol where Self: UIViewController{
-    func panView() -> UIView{
+extension UIViewController: PannableViewsProtocol{
+    @objc open func panView() -> UIView{
         if let scroll = self.view.subviews.first(where: {$0 is UIScrollView}){
             return scroll
         }else{
@@ -21,5 +21,3 @@ extension PannableViewsProtocol where Self: UIViewController{
         }
     }
 }
-
-extension UIViewController: PannableViewsProtocol{}


### PR DESCRIPTION
Closes #20 

Made `PannableViewsProtocol` public to allow `func panView() -> UIView` be overrided